### PR TITLE
Checkstyle CI step fails because of Javadoc 

### DIFF
--- a/singleton/src/main/java/com/agileactors/SingletonEnum.java
+++ b/singleton/src/main/java/com/agileactors/SingletonEnum.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Enum types are considered as the best practice for Singletons
+ * Enum types are considered as the best practice for Singletons.
  */
 public enum SingletonEnum {
 


### PR DESCRIPTION
Checkstyle [ci job](https://github.com/agileactors/design-patterns/actions/runs/3658471456/jobs/6183305225) fails because there is a Javadoc sentence without a period in the end.

```
[ERROR] /home/runner/work/design-patterns/design-patterns/singleton/src/main/java/com/agileactors/SingletonEnum.java:6: First sentence of Javadoc is missing an ending period. [SummaryJavadoc]
```

Added a full stop 😁 